### PR TITLE
Let ComponentCollection implement Iterable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 
 org.gradle.jvmargs = -Xmx1536M
 
-sar_version = 0.2.5
+sar_version = 0.3.0
 
 java_version = 17
 minecraft_version = 1.18.2

--- a/src/main/java/net/immortaldevs/sar/api/ComponentCollection.java
+++ b/src/main/java/net/immortaldevs/sar/api/ComponentCollection.java
@@ -1,6 +1,8 @@
 package net.immortaldevs.sar.api;
 
-public interface ComponentCollection {
+import java.util.Iterator;
+
+public interface ComponentCollection extends Iterable<SkeletalComponentData> {
     int size();
 
     boolean isEmpty();
@@ -14,4 +16,21 @@ public interface ComponentCollection {
     void clear();
 
     SkeletalComponentData get(int i);
+
+    @Override
+    default Iterator<SkeletalComponentData> iterator() {
+       return new Iterator<>() {
+           int index = 0;
+
+           @Override
+           public boolean hasNext() {
+               return index < size();
+           }
+
+           @Override
+           public SkeletalComponentData next() {
+               return get(index++);
+           }
+       };
+    }
 }


### PR DESCRIPTION
Previously, iterating through components, like is done in Skewer, would have to be done using:
```java
ComponentCollection foods = stack.getComponents("foods");
for (int i = 0; i < foods.size(); i++) {
    tooltip.add(new LiteralText(foods.get(i).getComponent().getId().toString()));
}
```
Now, it can be done with just:
```java
for (var data : stack.getComponents("foods")) {
    tooltip.add(new LiteralText(data.getComponent().getId().toString()));
}
```