### PR TITLE
ComponentCollection contains() method

### DIFF
--- a/src/main/java/net/immortaldevs/sar/api/ComponentCollection.java
+++ b/src/main/java/net/immortaldevs/sar/api/ComponentCollection.java
@@ -17,6 +17,23 @@ public interface ComponentCollection extends Iterable<SkeletalComponentData> {
 
     SkeletalComponentData get(int i);
 
+    /**
+     * @return Whether this ComponentCollection contains the provided
+     *         SkeletalComponentData or Component.
+     */
+    // The parameter is an Object to reflect Java's Collection interface
+    default boolean contains(Object o) {
+        if (isEmpty()) return false;
+
+        for (var datum : this) {
+            if (datum.equals(o) || datum.getComponent().equals(o)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     @Override
     default Iterator<SkeletalComponentData> iterator() {
        return new Iterator<>() {


### PR DESCRIPTION
Currently, in skewer, the following code is present (paraphrased, I don't remember exactly):
```java
for (var component : collection) {
    if (component.equals(this)) {
        /* do a thing */
        break;
    }
}
```
This pull request allows this to be replaced with:
```java
if (collection.contains(this)) {
    /* do a thing */
}
```